### PR TITLE
Change the process for optimising on guest counts.

### DIFF
--- a/src/Los/Transformer/ArrayRecordTransformer.php
+++ b/src/Los/Transformer/ArrayRecordTransformer.php
@@ -1,105 +1,72 @@
 <?php
-
-namespace Aptenex\Upp\Los\Transformer;
-
-use Aptenex\Upp\Exception\CannotGenerateLosException;
-use Aptenex\Upp\Los\LosRecords;
-use Money\Currency;
-
-/**
- * This array -> record transformer mimics Airbnb's format near identical just with multiple currencies
- *
- * @package Los\Transformer
- */
-class ArrayRecordTransformer extends BaseRecordTransformer
-{
+    
+    namespace Aptenex\Upp\Los\Transformer;
+    
+    use Aptenex\Upp\Exception\CannotGenerateLosException;
+    use Aptenex\Upp\Los\LosRecords;
+    use Money\Currency;
     
     /**
-     * @param LosRecords       $records
-     * @param TransformOptions $options
+     * This array -> record transformer mimics Airbnb's format near identical just with multiple currencies
      *
-     * @return array Format is [ los_string, los_string, los_string ]
+     * @package Los\Transformer
      */
-    public function transform(LosRecords $records, TransformOptions $options): array
+    class ArrayRecordTransformer extends BaseRecordTransformer
     {
-        if (empty($records->getRecords())) {
-            return [];
-        }
         
-        $data = [];
-        
-        // We do this so that we know if we need to do any conversion using the Exchange.
-        $options->setSourceCurrency(new Currency($records->getCurrency()));
-        
-        $computedEmptyHash = null;
-        
-        foreach ($records->getRecords() as $date => $dateSet) {
-            // We need a lookahead to merge the first guest count if a few guest counts have the same rate
-            // this is because there is no way to compare the first hash to the previous hash on the first one
-            $firstLookahead           = $dateSet[1] ?? null;
-            $previousSingleRecord     = null;
-            $maxGuestCountForSameHash = 0;
-            $guestEntries             = count($dateSet);
-            foreach ($dateSet as $index => $singleRecord) {
-                $isLastGuestEntry = $index !== ($guestEntries - 1);
-                
-                if ($index === 0 && $computedEmptyHash === null) {
-                    // We need to compute the hash of all 0's in a string, but we do it here as this transformer
-                    // does not know the MAXIMUM stay length so we can just get it here on the very first instance
-                    $computedEmptyHash = sha1(implode(',', array_fill(0, count($singleRecord['rates']), 0)));
-                }
-                // If we reach the END of the guest range and the hash still has not changed -
-                // we need to add at least one entry!
-                if ($options->isRestrictSameGuestRatesToSingleOccupancy() && $isLastGuestEntry &&
-                    $this->previousHashGuestLookaheadSatisfied($previousSingleRecord, $singleRecord, $firstLookahead, $index) ){
-                    
-                    $maxGuestCountForSameHash = $singleRecord['guest']; // Skip
-                    $previousSingleRecord = $singleRecord;
-                    continue;
-                }
-                
-                // Should we skip empty records? Some might want to. Some might not.... (ie Booking.com does not like to)
-                if ($singleRecord['rateHash'] === $computedEmptyHash && $options->isSkipEmptyLosRecordsFromTransformation()) {
-                    continue;
-                }
-                
-                if (! isset($data[$date]) && $options->isIndexRecordsByDate()) {
-                    $data[$date] = [];
-                }
-                
-                // Hash does not match that means we need to finally add the entry for the previous entries
-                // We also need to perform the check if this is the LAST index because
-                // if all the rates are exactly the same then $maxGuestCountForSameHash !== 0 = true
-                // so we'll be adding two records one for the previous guest count and one for the last index guest count
-                // this extra index check
-                if ($maxGuestCountForSameHash !== 0 && $isLastGuestEntry) {
-                    if ($options->isIndexRecordsByDate()) {
-                        $data[$date][] = $this->generateLosRecordString($previousSingleRecord, $options);
-                    } else {
-                        $data[] = $this->generateLosRecordString($previousSingleRecord, $options);
-                    }
-                    $maxGuestCountForSameHash = 0;
-                }
-                
-                if ($options->isIndexRecordsByDate()) {
-                    $data[$date][] = $this->generateLosRecordString($singleRecord, $options);
-                } else {
-                    $data[] = $this->generateLosRecordString($singleRecord, $options);
-                }
-                
-                $previousSingleRecord = $singleRecord;
+        /**
+         * @param LosRecords       $records
+         * @param TransformOptions $options
+         *
+         * @return array Format is [ los_string, los_string, los_string ]
+         */
+        public function transform(LosRecords $records, TransformOptions $options): array
+        {
+            if (empty($records->getRecords())) {
+                return [];
             }
+            
+            $data = [];
+            
+            // We do this so that we know if we need to do any conversion using the Exchange.
+            $options->setSourceCurrency(new Currency($records->getCurrency()));
+            
+            $computedEmptyHash = null;
+            foreach ($records->getRecords() as $date => $dateSet) {
+                // We need a lookahead to merge the first guest count if a few guest counts have the same rate
+                // this is because there is no way to compare the first hash to the previous hash on the first one
+                $firstLookahead           = $dateSet[1] ?? null;
+                $previousSingleRecord     = null;
+                $maxGuestCountForSameHash = 0;
+                $guestEntries             = count($dateSet);
+                $optimisedArrivalDateRates = [];
+                
+                // Array  which stores optimised guest rate prices. (no duplicate prices)
+                // We reverse the counts, bebcause the intention here is to only take the HIGHEST
+                // rateHash per guest count. The reason is we don't need to send, 1,2,3 prices, if the rate for
+                // 4 guests is all the same. We only need to provide the pricing for four. So, in turn we can stop
+                // execution if we know the 3 or 2 price is the same as the last hash.
+                foreach (array_reverse($dateSet) as $index => $singleRecord) {
+                    
+                    if ($index === 0 && $computedEmptyHash === null) {
+                        // We need to compute the hash of all 0's in a string, but we do it here as this transformer
+                        // does not know the MAXIMUM stay length so we can just get it here on the very first instance
+                        $computedEmptyHash = sha1(implode(',', array_fill(0, count($singleRecord['rates']), 0)));
+                    }
+                    
+                    // Should we skip empty records? Some might want to. Some might not.... (ie Booking.com does not like to)
+                    if ($singleRecord['rateHash'] === $computedEmptyHash && $options->isSkipEmptyLosRecordsFromTransformation()) {
+                        continue;
+                    }
+                    if($options->isRestrictSameGuestRatesToSingleOccupancy() && !isset($optimisedArrivalDateRates[$singleRecord['rateHash']]) || !$options->isRestrictSameGuestRatesToSingleOccupancy()) {
+                        $optimisedArrivalDateRates[$singleRecord['rateHash']] = $this->generateLosRecordString($singleRecord, $options);
+                    }
+                    
+                    $previousSingleRecord = $singleRecord;
+                }
+                $data = array_merge($data, array_reverse($optimisedArrivalDateRates));
+                
+            }
+            return $data;
         }
-        
-        return $data;
     }
-    
-    private function previousHashGuestLookaheadSatisfied($previousSingleRecord, $singleRecord, $firstLookahead, $index): bool
-    {
-        return
-            ($previousSingleRecord !== null && $previousSingleRecord['rateHash'] === $singleRecord['rateHash']) ||
-            ($index === 0 && $firstLookahead !== null && $firstLookahead['rateHash'] === $singleRecord['rateHash']);
-        
-    }
-    
-}


### PR DESCRIPTION
Rather than have a complicated lookup, just assume the LOS pricing is sorted
Then reverse, and store the values in an array based on rateHash.

Means that we can always be sure we never duplicate guests.